### PR TITLE
add support for variable expansion in config files

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -46,7 +46,8 @@ _tmux_conf_contents() {
 # return files sourced from tmux config files
 _sourced_files() {
 	_tmux_conf_contents |
-		sed -E -n -e "s/^[[:space:]]*source(-file)?[[:space:]]+(-q+[[:space:]]+)?['\"]?([^'\"]+)['\"]?/\3/p"
+		sed -E -n -e "s/^[[:space:]]*source(-file)?[[:space:]]+(-q+[[:space:]]+)?['\"]?([^'\"]+)['\"]?/\3/p" |
+		sed -E -n -e "s/^(.*)$/echo \"\1\"/p" | /usr/bin/env bash
 }
 
 # Want to be able to abort in certain cases


### PR DESCRIPTION
If tmux.conf refers other file by source-file command that uses variable, it'll be better to expand variables into actual values.